### PR TITLE
Tweak CI to not run on push

### DIFF
--- a/.github/workflows/CI_docs_build_and_check.yml
+++ b/.github/workflows/CI_docs_build_and_check.yml
@@ -21,7 +21,11 @@ jobs:
       - uses: actions/checkout@v2
 
       # Set up Python
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
+      # The following should be temporary ... right now, the default goes to 3.9, but many wheels
+      # are still missing for this version.
+        with:
+            python-version: '3.8'
 
       # Install any dependency we require
       - name: Install dependancies

--- a/.github/workflows/CI_docs_build_and_check.yml
+++ b/.github/workflows/CI_docs_build_and_check.yml
@@ -3,8 +3,8 @@
 name: CI_docs_check
 
 on:
-  push:
-    branches: [ master ]
+  #push:
+  #   branches: [ master ]
   pull_request:
     branches: [ master, develop ]
 

--- a/.github/workflows/CI_pylinter.yml
+++ b/.github/workflows/CI_pylinter.yml
@@ -25,7 +25,11 @@ jobs:
       - uses: actions/checkout@v2
 
       # Set up Python
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
+      # The following should be temporary ... right now, the default goes to 3.9, but many wheels
+      # are still missing for this version.
+        with:
+            python-version: '3.8'
 
       # Install any dependency we require
       - name: Install dependancies

--- a/.github/workflows/CI_pylinter.yml
+++ b/.github/workflows/CI_pylinter.yml
@@ -7,8 +7,8 @@
 name: CI_pylinter
 
 on:
-  push:
-    branches: [ master ]
+  #push:
+  #  branches: [ master ]
   pull_request:
     branches: [ master, develop ]
 

--- a/.github/workflows/CI_pytest.yml
+++ b/.github/workflows/CI_pytest.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Setup python
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/CI_pytest.yml
+++ b/.github/workflows/CI_pytest.yml
@@ -9,8 +9,8 @@
 name: CI_pytest
 
 on:
-  push:
-    branches: [ master ]
+  #push:
+  #  branches: [ master ]
   pull_request:
     branches: [ master, develop ]
 


### PR DESCRIPTION
**Description:**

This PR ensures that most CI actions do get triggered on pull request, but not on on pushes to master, since this is not strictly required.

This also forces to use Python 3.8 rather than the "defaults" which goes to 3.9 these days ... and for which installing packages takes forever since not all wheels are available (yet).

**Checklists**:
- [ ] New code includes dedicated tests.
- [ ] New code has been linted.
- [x] New code follows the project's style.
- [x] New code is compatible with BSD 3-Clause license.
- [ ] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
