### PR TITLE
Optimize sen slope(), yielding identical results.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added:
 ### Changed:
+ - [stasinos, 07/07/2022] Runtime optimizations for sen_slope()
 ### Deprecated:
 ### Removed:
 ### Fixed:

--- a/src/mannkendall/mk_stats.py
+++ b/src/mannkendall/mk_stats.py
@@ -92,8 +92,14 @@ def sen_slope(obs_dts, obs, k_var, alpha_cl=90.):
     # Let's only keep the values that are valid
     d = d[~np.isnan(d)]
 
-    # Let's compute the median slope
-    slope = np.nanmedian(d)
+    # Sort now to get the median and also to have
+    # the array sorted for finding lcl, ucl below
+    d.sort()
+    l = len(d)
+    if l % 2 == 1:
+        slope = d[(l-1)//2]
+    else:
+        slope = (d[l//2-1]+d[l//2])/2
 
     # Apply the confidence limits
     cconf = -norm.ppf((1-alpha_cl/100)/2) * k_var**0.5
@@ -104,10 +110,8 @@ def sen_slope(obs_dts, obs, k_var, alpha_cl=90.):
     m_2 = (0.5 * (len(d) + cconf)) - 1
 
     # Let's setup a quick interpolation scheme to get the best possible confidence limits
-    f = interp1d(np.arange(0, len(d), 1), np.sort(d), kind='linear',
-                 fill_value=(np.sort(d)[0], np.sort(d)[-1]),
-                 assume_sorted=True, bounds_error=False)
-
+    f = interp1d(np.arange(0, len(d), 1), d, kind='linear',
+                 fill_value=(d[0], d[-1]), assume_sorted=True, bounds_error=False)
     lcl = f(m_1)
     ucl = f(m_2)
 

--- a/src/mannkendall/mk_stats.py
+++ b/src/mannkendall/mk_stats.py
@@ -83,14 +83,15 @@ def sen_slope(obs_dts, obs, k_var, alpha_cl=90.):
     if not isinstance(k_var, (int, float)):
         raise Exception('Ouch ! The variance must be of type float, not: %s' % (type(k_var)))
 
+    # Let's only keep the values that are valid
+    obs_dts = obs_dts[~np.isnan(obs)]
+    obs = obs[~np.isnan(obs)]
+
     l = len(obs)
 
     # Let's compute the slope for all the possible pairs.
     d = np.array([item for i in range(0, l-1)
                   for item in list((obs[i+1:l] - obs[i])/mkt.dt_to_s(obs_dts[i+1:l] - obs_dts[i]))])
-
-    # Let's only keep the values that are valid
-    d = d[~np.isnan(d)]
 
     # Sort now to get the median and also to have
     # the array sorted for finding lcl, ucl below


### PR DESCRIPTION
Commit 329da7de09246f648968b1477f96dbffca669e76 sorts the array of slopes and uses the sorted array to find slope, lcl, and ucl. This avoids sorting the same data multiple times.

Commit 3949249064686e6cdee374b90b18a0744b0c4fe6 changes the order of checking for NaNs and iterating through the obs array to create the array of all slopes. This avoids adding NaNs in the array of slopes just to remove them immediatelly afterwards.

The runtimes gains are significant. Here are the results on an i5-8400 @ 2.80GHz:

Using v1.1.0: 433.10 sec
After applying 329da7d "Avoid gratuitous sorting": 348.60 sec
After applying both patches: 248.31 sec


pytest log using v1.1.0:


============================================================== test session starts ===============================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/konstant/projects/atmo/dataeng-mannkendall
collected 16 items                                                                                                                               

test/test_mk_hardcoded.py .                                                                                                                [  6%]
test/test_mk_main.py ....                                                                                                                  [ 31%]
test/test_mk_stats.py ...                                                                                                                  [ 50%]
test/test_mk_tools.py ......                                                                                                               [ 87%]
test/test_mk_white.py ..                                                                                                                   [100%]

================================================================ warnings summary ================================================================
test/test_mk_main.py::test_mk_temp_aggr_single
  /home/konstant/projects/atmo/dataeng-mannkendall/src/mannkendall/mk_main.py:371: UserWarning: The trends for the temporal aggregation are not homogenous.
    warnings.warn('The trends for the temporal aggregation are not homogenous.')

test/test_mk_white.py::test_nanprewhite_arok
test/test_mk_white.py::test_prewhite
  /home/konstant/projects/atmo/dataeng-mannkendall/src/mannkendall/mk_white.py:94: UserWarning: No statistically significant autocorrelation.
    warnings.warn('No statistically significant autocorrelation.')

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================== 16 passed, 3 warnings in 433.10s (0:07:13) ===================================================


pytest log after applying 329da7d:


============================================================== test session starts ===============================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/konstant/projects/atmo/dataeng-mannkendall
collected 16 items                                                                                                                               

test/test_mk_hardcoded.py .                                                                                                                [  6%]
test/test_mk_main.py ....                                                                                                                  [ 31%]
test/test_mk_stats.py ...                                                                                                                  [ 50%]
test/test_mk_tools.py ......                                                                                                               [ 87%]
test/test_mk_white.py ..                                                                                                                   [100%]

================================================================ warnings summary ================================================================
test/test_mk_main.py::test_mk_temp_aggr_single
  /home/konstant/projects/atmo/dataeng-mannkendall/src/mannkendall/mk_main.py:371: UserWarning: The trends for the temporal aggregation are not homogenous.
    warnings.warn('The trends for the temporal aggregation are not homogenous.')

test/test_mk_white.py::test_nanprewhite_arok
test/test_mk_white.py::test_prewhite
  /home/konstant/projects/atmo/dataeng-mannkendall/src/mannkendall/mk_white.py:94: UserWarning: No statistically significant autocorrelation.
    warnings.warn('No statistically significant autocorrelation.')

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================== 16 passed, 3 warnings in 348.60s (0:05:48) ===================================================



pytest log after applying both:

============================================================== test session starts ===============================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/konstant/projects/atmo/dataeng-mannkendall
collected 16 items                                                                                                                               

test/test_mk_hardcoded.py .                                                                                                                [  6%]
test/test_mk_main.py ....                                                                                                                  [ 31%]
test/test_mk_stats.py ...                                                                                                                  [ 50%]
test/test_mk_tools.py ......                                                                                                               [ 87%]
test/test_mk_white.py ..                                                                                                                   [100%]

================================================================ warnings summary ================================================================
test/test_mk_main.py::test_mk_temp_aggr_single
  /home/konstant/projects/atmo/dataeng-mannkendall/src/mannkendall/mk_main.py:371: UserWarning: The trends for the temporal aggregation are not homogenous.
    warnings.warn('The trends for the temporal aggregation are not homogenous.')

test/test_mk_white.py::test_nanprewhite_arok
test/test_mk_white.py::test_prewhite
  /home/konstant/projects/atmo/dataeng-mannkendall/src/mannkendall/mk_white.py:94: UserWarning: No statistically significant autocorrelation.
    warnings.warn('No statistically significant autocorrelation.')

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================== 16 passed, 3 warnings in 248.31s (0:04:08) ===================================================


